### PR TITLE
center image

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -1717,7 +1717,7 @@ pre.runkit-element {
 }
 
 .post-full-content figure img {
-  margin: 0;
+  margin: 0 auto;
 }
 
 .post-full-content figcaption {


### PR DESCRIPTION
some images such as the image above https://www.freecodecamp.org/news/android-menus-introduction/#contextual-menu
are not centered.
<img width="1107" alt="Screen Shot 2020-07-22 at 7 53 40 PM" src="https://user-images.githubusercontent.com/4591597/88206298-b68a6b80-cc56-11ea-91d6-6bde4135f627.png">

adding auto to the sides centers the images.
<img width="1032" alt="Screen Shot 2020-07-22 at 8 03 50 PM" src="https://user-images.githubusercontent.com/4591597/88206288-b4281180-cc56-11ea-9430-6da31aa2bf0b.png">


