### PR TITLE
Revert "fix: remove extra gets helpers on articles"

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -96,6 +96,57 @@ into the {body} of the default.hbs template --}}
     </div>
 </main>
 
+
+
+
+
+{{!-- Links to Previous/Next posts --}}
+<aside class="read-next outer">
+    <div class="inner">
+        <div class="read-next-feed">
+            {{#if primary_tag}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:-{{comment_id}}" limit="3" as |related_posts|}}
+            {{#if related_posts}}
+            <article class="read-next-card" {{#if ../primary_tag.feature_image}}
+                style="background-image: url({{img_url ../primary_tag.feature_image size="m"}})" {{else}}
+                {{#if @site.cover_image}} style="background-image: url({{img_url @site.cover_image size="m"}})" {{/if}}
+                {{/if}}>
+                <header class="read-next-card-header">
+                    <p class="read-next-card-header-sitetitle">Countinue reading about</p>
+                    {{#../primary_tag}}
+                    <h3 class="read-next-card-header-title"><a href="{{url}}">{{name}}</a></h3>
+                    {{/../primary_tag}}
+                </header>
+                <div class="read-next-card-content">
+                    <ul>
+                        {{#foreach related_posts}}
+                        <li><a href="{{url}}">{{title}}</a></li>
+                        {{/foreach}}
+                    </ul>
+                </div>
+                <footer class="read-next-card-footer">
+                    <a href="{{#../primary_tag}}{{url}}{{/../primary_tag}}">{{plural meta.pagination.total empty='No posts' singular='% post' plural='See all % posts'}}
+                        →</a>
+                </footer>
+            </article>
+            {{/if}}
+            {{/get}}
+            {{/if}}
+
+            {{!-- If there's a next post, display it using the same markup included from - partials/post-card.hbs --}}
+            {{#next_post}}
+            {{> "post-card"}}
+            {{/next_post}}
+
+            {{!-- If there's a previous post, display it using the same markup included from - partials/post-card.hbs --}}
+            {{#prev_post}}
+            {{> "post-card"}}
+            {{/prev_post}}
+
+        </div>
+    </div>
+</aside>
+
 {{/post}}
 
 {{!-- The #contentFor helper here will send everything inside it up to the matching #block helper found in default.hbs --}}


### PR DESCRIPTION
This reverts commit eb898572e6045d790d71a73a7708e8cca2e61553.

![image](https://user-images.githubusercontent.com/4591597/90753268-0ead9f80-e2e1-11ea-9e39-bec9750ee75e.png)
