### PR TITLE
fix(news): prevent content from being cut off on mobile

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -500,8 +500,7 @@ a.nav-forum {
 
 .post-card-meta {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   padding: 0 25px 25px 4px;
 }
 
@@ -621,6 +620,13 @@ a.nav-forum {
   }
 }
 
+.meta-content {
+  display: flex;
+  flex-wrap: wrap;
+  flex: auto;
+  justify-content: space-between;
+}
+
 .meta-item,
 .reading-time {
   flex-shrink: 0;
@@ -631,10 +637,6 @@ a.nav-forum {
   font-weight: 500;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-}
-
-time.meta-item {
-  margin-left: auto;
 }
 
 .meta-item-single {

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -454,7 +454,7 @@ a.nav-forum {
   width: 100%;
   height: 200px;
   background: var(--gray15) no-repeat center center;
-  object-fit: fill;
+  object-fit: cover;
 }
 
 .post-card-content-link {
@@ -633,7 +633,7 @@ a.nav-forum {
   margin-left: 20px;
   color: var(--gray75);
   font-size: 1.2rem;
-  line-height: 33px;
+  line-height: 20px;
   font-weight: 500;
   letter-spacing: 0.5px;
   text-transform: uppercase;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -454,7 +454,7 @@ a.nav-forum {
   width: 100%;
   height: 200px;
   background: var(--gray15) no-repeat center center;
-  object-fit: cover;
+  object-fit: fill;
 }
 
 .post-card-content-link {
@@ -500,6 +500,7 @@ a.nav-forum {
 
 .post-card-meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   padding: 0 25px 25px 4px;
 }
@@ -630,6 +631,10 @@ a.nav-forum {
   font-weight: 500;
   letter-spacing: 0.5px;
   text-transform: uppercase;
+}
+
+time.meta-item {
+  margin-left: auto;
 }
 
 .meta-item-single {

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -64,11 +64,13 @@
                 {{/foreach}}
             </ul>
 
-            {{#primary_author}}
-            <a class="meta-item" href="{{url}}">{{name}}</a>
-            {{/primary_author}}
-            {{!-- <time class="meta-item time-ago" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}"></time> --}}
-            <time class="meta-item">{{date published_at timeago="true"}}</time>
+            <span class="meta-content">
+                {{#primary_author}}
+                <a class="meta-item" href="{{url}}">{{name}}</a>
+                {{/primary_author}}
+                {{!-- <time class="meta-item time-ago" datetime="{{date format="YYYY-MM-DDTHH:mm:ss.SS\Z"}}"></time> --}}
+                <time class="meta-item">{{date published_at timeago="true"}}</time>
+            </span>
 
             {{/has}}
 


### PR DESCRIPTION
#### Summary

- Prevented news image thumbnails (especially those with text) from being clipped off on small screen mobile devices and tablets
- Fixed news publication date/time ago span being cut off on small screen mobile phones

#### Linked Issue

Fixes [#40858](https://github.com/freeCodeCamp/freeCodeCamp/issues/40858)

#### Screenshots

**1.** images **before**, shown on tablet

![screenshot1](https://user-images.githubusercontent.com/46979603/106680080-36a66c00-65be-11eb-82a4-aae71c7a6c45.jpg)

**2.** images **after**, shown on tablet

![screenshot2](https://user-images.githubusercontent.com/46979603/106680134-5a69b200-65be-11eb-9f46-25db702e2d68.jpg)

**3.** time span **before**, shown on mobile

![screenshot3](https://user-images.githubusercontent.com/46979603/106680220-7ec58e80-65be-11eb-98f7-755e98f01817.jpg)

**4.** time span **after**, shown on mobile

![screenshot4](https://user-images.githubusercontent.com/46979603/106680239-8a18ba00-65be-11eb-832a-b6bcf75ccee6.jpg)
