### PR TITLE
fix: Español banner link

### DIFF
--- a/assets/config/es/main.js
+++ b/assets/config/es/main.js
@@ -4,5 +4,5 @@ const esMain = {
   'learn-to-code-cta-url': 'https://www.freecodecamp.org/espanol/learn/',
   'forum-url': 'https://forum.freecodecamp.org/c/espanol/522',
   'donate-url': 'https://www.freecodecamp.org/espanol/donate/',
-  'banner-url': 'https://www.freecodecamp.org/espanol/'
+  'banner-url': 'https://chat.freecodecamp.org/home'
 };


### PR DESCRIPTION
The banner link for Español News should point to the chatroom.