### PR TITLE
fix: remove unnecessary comma in footer

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -5,7 +5,7 @@
   "learn-to-code-cta-btn": "Get started",
   "footer-desc-1": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
   "footer-desc-2": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
-  "footer-desc-3": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
+  "footer-desc-3": "Donations to freeCodeCamp go toward our education initiatives and help pay for servers, services, and staff.",
   "footer-donation": "You can <a id='footer-donation' class='inline' rel='noopener noreferrer' target='_blank'>make a tax-deductible donation here</a>.",
   "footer-trending-guides-header": "Trending Guides",
   "footer-our-nonprofit-header": "Our Nonprofit",


### PR DESCRIPTION

It appears that unnecessary comma in a compound predicate. 