### PR TITLE
fix: provide size hints for image cards

### DIFF
--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -9,7 +9,7 @@
                     {{img_url feature_image size="m"}} 600w,
                     {{img_url feature_image size="l"}} 1000w,
                     {{img_url feature_image size="xl"}} 2000w"
-            sizes="(min-width: 768px) 285px, 100vw"
+            sizes="(max-width: 360px) 300px, (max-width: 655px) 600px, (max-width: 767px) 1000px, (min-width: 768px) 300px, 92vw"
             onerror="this.style.display='none'" src="{{img_url feature_image size="m"}}" alt="{{title}}" />
     </a>
     {{else}}


### PR DESCRIPTION
Smaller screens need hints so that the browser does not use the default
when selecting images

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
