### PR TITLE
fix: generate and display smaller author images

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -5,7 +5,7 @@
 {{!-- Everything inside the #author tags pulls data from the author --}}
 <div class="under-header-content">
     {{#if profile_image}}
-    <img class="author-profile-image" src="{{profile_image}}" alt="{{name}}" />
+    <img class="author-profile-image" src="{{img_url profile_image size="profile"}}" alt="{{name}}" />
     {{/if}}
     <h1 class="site-title">{{name}}</h1>
     {{#if bio}}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
             "xs": {
                 "width": 100
             },
+            "profile": {
+                "width": 150
+            },
             "s": {
                 "width": 300
             },

--- a/partials/post-card.hbs
+++ b/partials/post-card.hbs
@@ -55,7 +55,7 @@
 
                     {{#if profile_image}}
                     <a href="{{url}}" class="static-avatar">
-                        <img class="author-profile-image" src="{{img_url profile_image size="xs"}}" alt="{{name}}" />
+                        <img class="author-profile-image" src="{{img_url profile_image size="xxs"}}" alt="{{name}}" />
                     </a>
                     {{else}}
                     <a href="{{url}}" class="static-avatar author-profile-image">{{> "icons/avatar"}}</a>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

For authors who uploaded their profile pictures to Ghost directly, this will allow us to generate extra small (30px wide) versions for the landing page.

More importantly, this adds a special 150px wide "profile" image size for the large image at the top of the author pages. Currently we don't do any resizing, so the main author profile images are shown at whatever resolution they were uploaded at.

This doesn't fix the issue of author profiles where their image is coming from Gravatar. Those will need to be handled separately. 
