### PR TITLE
fix: search results dates and cards

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -54,6 +54,7 @@
 
     {{!-- Day.js locales --}}
     <script defer src="https://cdn.freecodecamp.org/news-assets/dayjs-1.9.1/locale/zh-cn.min.js"></script>
+    <script defer src="https://cdn.freecodecamp.org/news-assets/dayjs-1.9.1/locale/es.min.js"></script>
 
     {{#is "home"}}
         <meta name='keywords' content="{{t 'keyword-meta'}}" >

--- a/search-results.hbs
+++ b/search-results.hbs
@@ -33,7 +33,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function renderSearchResults(arr) {
     arr.forEach((hit, i) => {
-      const featureImage = hit.featureImage || "#";
+      const featureImage = hit.featureImage || null;
       const url = hit.url || "#";
       const title = hit.title || "#";
       const authorName = hit.author.name;
@@ -49,49 +49,73 @@ document.addEventListener('DOMContentLoaded', () => {
       const timeEl = `<time class="post-full-meta-date ${dateStylingClassName}" datetime="${publishedAt}"></time>`;
       const displayAuthorAndTime = () => {
         return authorName === 'freeCodeCamp.org' ? timeEl : `
-            <ul class="author-list">
-              <li class="author-list-item">
-                <div class="author-name-tooltip">
-                  ${authorName}
-                </div>
+          <ul class="author-list">
+            <li class="author-list-item">
+              <div class="author-name-tooltip">
+                ${authorName}
+              </div>
+              ${authorImage ? `
                 <a href="${authorUrl}" class="static-avatar">
                   <img class="author-profile-image" src="${authorImage}" alt="${authorName}">
                 </a>
-              </li>
-            </ul>
+              ` : `
+                <a href="{{url}}" class="static-avatar author-profile-image">{{> "icons/avatar"}}</a>
+              `}
+            </li>
+          </ul>
+          <span class="meta-content">
             <a class="meta-item" href="${authorUrl}">${authorName}</a>
             ${timeEl}
-          `;
+          </span>
+        `;
       }
 
       const articleItem = document.createElement('article');
-      articleItem.className = "post-card post tag-javascript tag-news featured post-card-large";
+      articleItem.className = "post-card post";
       const codeBlock = `
-          <a class="post-card-image-link" href="${url}">
-            <img class="post-card-image" srcset="${featureImage} 300w,
-              ${featureImage} 600w,
-              ${featureImage} 1000w,
-              ${featureImage} 2000w" sizes="(max-width: 1000px) 400px, 700px" src="${featureImage}" alt="${title}"
-            >
-          </a>
-          <div class="post-card-content">
-            <div class="post-card-content-link">
-              <header class="post-card-header">
-                <span class="post-card-tags">
-                  ${primaryTagCodeBlock}
-                </span>
-                <h2 class="post-card-title">
-                  <a href="${url}">
-                    ${title}
-                  </a>
-                </h2>
-              </header>
-            </div>
-            <footer class="post-card-meta">
-              ${displayAuthorAndTime()}
-            </footer>
+          ${featureImage ? `
+            <a class="post-card-image-link" href="${url}">
+              <img
+                class="post-card-image"
+                srcset="
+                  ${featureImage}  300w,
+                  ${featureImage}  600w,
+                  ${featureImage} 1000w,
+                  ${featureImage} 2000w
+                "
+                sizes="
+                  (max-width: 360px) 300px,
+                  (max-width: 655px) 600px,
+                  (max-width: 767px) 1000px,
+                  (min-width: 768px) 300px,
+                  92vw
+                "
+                onerror="this.style.display='none'"
+                src="${featureImage}"
+                alt="${title}"
+              />
+            </a>
+          ` : `
+            <div class="no-feature-image-offsetter"></div>
+          `}
+        <div class="post-card-content">
+          <div class="post-card-content-link">
+            <header class="post-card-header">
+              <span class="post-card-tags">
+                ${primaryTagCodeBlock}
+              </span>
+              <h2 class="post-card-title">
+                <a href="${url}">
+                  ${title}
+                </a>
+              </h2>
+            </header>
           </div>
-        `;
+          <footer class="post-card-meta">
+            ${displayAuthorAndTime()}
+          </footer>
+        </div>
+      `;
 
       articleItem.innerHTML = codeBlock;
       postFeed.appendChild(articleItem);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This PR adds the dayjs `es` locale to format the dates on the search results page properly.

It also updates the post cards on the search results page to match the recent changes to the post cards on landing, tags, and author pages.

Some conditional checks for a feature image and author profile photo are added to better mirror the `post-card.hbs` template:

If there's no author image, we'll show the author avatar instead:

![image](https://user-images.githubusercontent.com/2051070/118226854-7e446a00-b4c2-11eb-93b9-7e05a2e103bf.png)

And if there's no feature image, we'll render a `div` element with the class `no-feature-image-offsetter`:

![image](https://user-images.githubusercontent.com/2051070/118227062-e09d6a80-b4c2-11eb-9fff-bfc51ce96dba.png)

This can be tested locally using the dev Algolia app ID to `algoliasearch` in `search-results.hbs` and going to http://localhost:2368/search/?query=python to see posts with no feature images, and http://localhost:2368/search/?query=instagram to see an author with no profile photo.

Note: This should not be deployed until after https://github.com/freeCodeCamp/cdn/pull/70 is merged.