### PR TITLE
fix: author names

### DIFF
--- a/partials/byline-multiple.hbs
+++ b/partials/byline-multiple.hbs
@@ -16,7 +16,7 @@
                     {{else}}
                         <div class="author-profile-image">{{> "icons/avatar"}}</div>
                     {{/if}}
-                    <h2>{{name}}</h2>
+                    <span>{{name}}</span>
                 </div>
                 <div class="bio">
                     {{#if bio}}

--- a/partials/byline-single-no-bio.hbs
+++ b/partials/byline-single-no-bio.hbs
@@ -8,7 +8,7 @@
     <span class="avatar-wrapper">{{> "icons/avatar"}}</span>
     {{/if}}
     <section class="author-card-content author-card-content-no-bio">
-        <h4 class="author-card-name"><a href="{{url}}">{{name}}</a></h4>
+        <span class="author-card-name"><a href="{{url}}">{{name}}</a></span>
     </section>
 </section>
 

--- a/partials/byline-single.hbs
+++ b/partials/byline-single.hbs
@@ -8,7 +8,7 @@
     <span class="avatar-wrapper">{{> "icons/avatar"}}</span>
     {{/if}}
     <section class="author-card-content">
-        <h4 class="author-card-name"><a href="{{url}}">{{name}}</a></h4>
+        <span class="author-card-name"><a href="{{url}}">{{name}}</a></span>
         {{#if bio}}
         <p>{{bio}}</p>
         {{else}}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Our theme currently uses `h4` elements for the author names on posts. This causes issues with Lighthouse as it is not semantic HTML. Changing these to `span` elements preserves the appearance locally, due to the styling applied by the class, and resolves the semantic issue. 