### PR TITLE
fix: spacing around tags

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -451,6 +451,7 @@ a.nav-forum {
   position: relative;
   display: block;
   overflow: hidden;
+  margin-bottom: 1.2rem;
 }
 
 .post-card-image {
@@ -474,7 +475,7 @@ a.nav-forum {
 .post-card-tags a {
   margin-bottom: 1.3rem;
   color: var(--gray75);
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   line-height: 1.15em;
   font-weight: 500;
   letter-spacing: 0.5px;
@@ -483,7 +484,7 @@ a.nav-forum {
 }
 
 .post-card-title {
-  margin-top: 0;
+  margin-top: 1rem;
 }
 
 .post-card-title a {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Resolves issue with tap targets being too small on mobile - the article tags needed additional spacing around them.

Screenshot:
<img width="1056" alt="tags" src="https://user-images.githubusercontent.com/63889819/121733181-0446d700-caa8-11eb-953f-4b9d130ace4a.png">
