### PR TITLE
fix: remove scrolling attribute from comments iframe

### DIFF
--- a/partials/comments.hbs
+++ b/partials/comments.hbs
@@ -41,6 +41,12 @@
               d.async = true;
               d.src = discourseUrl + 'javascripts/embed.js';
               (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(d);
+
+              // Remove deprecated scrolling attribute and handle with embedded CSS
+              d.onload = () => {
+                const discourseEmbedFrame = document.querySelector('#discourse-embed-frame');
+                discourseEmbedFrame.removeAttribute('scrolling');
+              }
             } else {
               document.getElementById('discourse-comments').innerHTML =
                 '<div style="text-align: center;">{{t "Sorry, we could not load the comments. Please try again after some time."}}</div>';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/forum-theme/pull/53

<!-- Feel free to add any additional description of changes below this line -->

This PR removes the deprecated `scrolling` attribute from the comments `iframe`. Instead, showing the scrollbar will be handled in [this update]() to the embedded CSS.