### PR TITLE
feat/add-ja-uk-langs

### DIFF
--- a/assets/config/ja/footer.js
+++ b/assets/config/ja/footer.js
@@ -1,0 +1,103 @@
+// eslint-disable-next-line no-unused-vars
+const jaFooter = {
+  trending: {
+    article0title: '10 to the Power of 0',
+    article0link:
+      'https://www.freecodecamp.org/news/10-to-the-power-of-0-the-zero-exponent-rule-and-the-power-of-zero-explained/',
+    article1title: 'Git Reset to Remote',
+    article1link:
+      'https://www.freecodecamp.org/news/git-reset-to-remote-head-how-to-reset-a-remote-branch-to-origin/',
+    article2title: 'R Value in Statistics',
+    article2link:
+      'https://www.freecodecamp.org/news/what-is-a-correlation-coefficient-r-value-in-statistics-explains/',
+    article3title: 'What is Economics?',
+    article3link: 'https://www.freecodecamp.org/news/what-is-economics/',
+    article4title: 'Module Exports',
+    article4link:
+      'https://www.freecodecamp.org/news/node-module-exports-explained-with-javascript-export-function-examples/',
+    article5title: 'Python VS JavaScript',
+    article5link:
+      'https://www.freecodecamp.org/news/python-vs-javascript-what-are-the-key-differences-between-the-two-popular-programming-languages/',
+    article6title: 'Model View Controller',
+    article6link: 'https://www.freecodecamp.org/news/model-view-architecture/',
+    article7title: 'React Testing Library',
+    article7link:
+      'https://www.freecodecamp.org/news/react-testing-library-tutorial-javascript-example-code/',
+    article8title: 'ASCII Table Chart',
+    article8link:
+      'https://www.freecodecamp.org/news/ascii-table-hex-to-ascii-value-character-code-chart-2/',
+    article9title: 'Data Validation',
+    article9link:
+      'https://www.freecodecamp.org/news/form-validation-with-html5-and-javascript/',
+    article10title: 'Recursion',
+    article10link:
+      'https://www.freecodecamp.org/news/what-is-recursion-in-javascript/',
+    article11title: 'ISO File',
+    article11link:
+      'https://www.freecodecamp.org/news/what-is-an-iso-file-explained-in-plain-english/',
+    article12title: 'ADB',
+    article12link:
+      'https://www.freecodecamp.org/news/adb-android-install-guide-drivers-and-commands/',
+    article13title: 'MBR VS GPT',
+    article13link:
+      'https://www.freecodecamp.org/news/mbr-vs-gpt-whats-the-difference-between-an-mbr-partition-and-a-gpt-partition-solved/',
+    article14title: 'Debounce',
+    article14link:
+      'https://www.freecodecamp.org/news/javascript-debounce-example/',
+    article15title: 'Helm Chart',
+    article15link:
+      'https://www.freecodecamp.org/news/what-is-a-helm-chart-tutorial-for-kubernetes-beginners/',
+    article16title: '80-20 Rule',
+    article16link:
+      'https://www.freecodecamp.org/news/the-80-20-rule-pareto-principle-explained-in-plain-english/',
+    article17title: 'OSI Model',
+    article17link:
+      'https://www.freecodecamp.org/news/osi-model-networking-layers-explained-in-plain-english/',
+    article18title: 'HTML Link Code',
+    article18link:
+      'https://www.freecodecamp.org/news/html-link-code-how-to-insert-a-link-to-a-website-with-href-3/',
+    article19title: 'SDLC',
+    article19link:
+      'https://www.freecodecamp.org/news/what-is-sdlc-software-development-life-cycle-phases-methodologies-and-processes-explained/',
+    article20title: 'Inductive VS Deductive',
+    article20link:
+      'https://www.freecodecamp.org/news/inductive-vs-deductive-reasoning/',
+    article21title: 'JavaScript Empty Array',
+    article21link:
+      'https://www.freecodecamp.org/news/check-if-javascript-array-is-empty-or-not-with-length/',
+    article22title: 'Best Instagram Post Time',
+    article22link:
+      'https://www.freecodecamp.org/news/the-best-time-to-post-on-instagram-the-best-days-and-times-to-reach-your-ig-followers/',
+    article23title: 'Garbage Collection in Java',
+    article23link:
+      'https://www.freecodecamp.org/news/garbage-collection-in-java-what-is-gc-and-how-it-works-in-the-jvm/',
+    article24title: 'Auto-Numbering in Excel',
+    article24link: 'https://www.freecodecamp.org/news/auto-numbering-in-excel/',
+    article25title: 'JavaScript Keycode List',
+    article25link:
+      'https://www.freecodecamp.org/news/javascript-keycode-list-keypress-event-key-codes/',
+    article26title: 'JavaScript Reverse Array',
+    article26link:
+      'https://www.freecodecamp.org/news/javascript-array-reverse-tutorial-with-example-js-code/',
+    article27title: 'How to Screenshot on Mac',
+    article27link:
+      'https://www.freecodecamp.org/news/how-to-take-a-screenshot-on-a-mac-keyboard-shortcut/',
+    article28title: 'How to Reverse Image Search',
+    article28link:
+      'https://www.freecodecamp.org/news/how-to-reverse-image-search-on-your-phone-or-desktop/',
+    article29title: 'Ternary Operator JavaScript',
+    article29link:
+      'https://www.freecodecamp.org/news/ternary-operator-javascript-if-statement-tutorial/'
+  },
+  about: 'https://www.freecodecamp.org/news/about/',
+  alumni: 'https://www.linkedin.com/school/free-code-camp/people/',
+  'open-source': 'https://github.com/freeCodeCamp/',
+  shop: 'https://www.freecodecamp.org/shop/',
+  support: 'https://www.freecodecamp.org/news/support/',
+  sponsors: 'https://www.freecodecamp.org/news/sponsors/',
+  honesty: 'https://www.freecodecamp.org/news/academic-honesty-policy/',
+  coc: 'https://www.freecodecamp.org/news/code-of-conduct/',
+  privacy: 'https://www.freecodecamp.org/news/privacy-policy/',
+  tos: 'https://www.freecodecamp.org/news/terms-of-service/',
+  copyright: 'https://www.freecodecamp.org/news/copyright-policy/'
+};

--- a/assets/config/ja/main.js
+++ b/assets/config/ja/main.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-unused-vars
+const jaMain = {
+  'algolia-index-name': 'news',
+  'learn-to-code-cta-url': 'https://www.freecodecamp.org/learn/',
+  'forum-url': 'https://forum.freecodecamp.org/',
+  'donate-url': 'https://www.freecodecamp.org/donate/',
+  'banner-url': 'https://www.freecodecamp.org/'
+};

--- a/assets/config/setup-locale.js
+++ b/assets/config/setup-locale.js
@@ -19,4 +19,10 @@ if (siteLang === 'en') {
 } else if (siteLang === 'it') {
   main = itMain;
   footer = itFooter;
+} else if (siteLang === 'ja') {
+  main = jaMain;
+  footer = jaFooter;
+} else if (siteLang === 'uk') {
+  main = ukMain;
+  footer = ukFooter;
 }

--- a/assets/config/uk/footer.js
+++ b/assets/config/uk/footer.js
@@ -1,0 +1,103 @@
+// eslint-disable-next-line no-unused-vars
+const ukFooter = {
+  trending: {
+    article0title: '10 to the Power of 0',
+    article0link:
+      'https://www.freecodecamp.org/news/10-to-the-power-of-0-the-zero-exponent-rule-and-the-power-of-zero-explained/',
+    article1title: 'Git Reset to Remote',
+    article1link:
+      'https://www.freecodecamp.org/news/git-reset-to-remote-head-how-to-reset-a-remote-branch-to-origin/',
+    article2title: 'R Value in Statistics',
+    article2link:
+      'https://www.freecodecamp.org/news/what-is-a-correlation-coefficient-r-value-in-statistics-explains/',
+    article3title: 'What is Economics?',
+    article3link: 'https://www.freecodecamp.org/news/what-is-economics/',
+    article4title: 'Module Exports',
+    article4link:
+      'https://www.freecodecamp.org/news/node-module-exports-explained-with-javascript-export-function-examples/',
+    article5title: 'Python VS JavaScript',
+    article5link:
+      'https://www.freecodecamp.org/news/python-vs-javascript-what-are-the-key-differences-between-the-two-popular-programming-languages/',
+    article6title: 'Model View Controller',
+    article6link: 'https://www.freecodecamp.org/news/model-view-architecture/',
+    article7title: 'React Testing Library',
+    article7link:
+      'https://www.freecodecamp.org/news/react-testing-library-tutorial-javascript-example-code/',
+    article8title: 'ASCII Table Chart',
+    article8link:
+      'https://www.freecodecamp.org/news/ascii-table-hex-to-ascii-value-character-code-chart-2/',
+    article9title: 'Data Validation',
+    article9link:
+      'https://www.freecodecamp.org/news/form-validation-with-html5-and-javascript/',
+    article10title: 'Recursion',
+    article10link:
+      'https://www.freecodecamp.org/news/what-is-recursion-in-javascript/',
+    article11title: 'ISO File',
+    article11link:
+      'https://www.freecodecamp.org/news/what-is-an-iso-file-explained-in-plain-english/',
+    article12title: 'ADB',
+    article12link:
+      'https://www.freecodecamp.org/news/adb-android-install-guide-drivers-and-commands/',
+    article13title: 'MBR VS GPT',
+    article13link:
+      'https://www.freecodecamp.org/news/mbr-vs-gpt-whats-the-difference-between-an-mbr-partition-and-a-gpt-partition-solved/',
+    article14title: 'Debounce',
+    article14link:
+      'https://www.freecodecamp.org/news/javascript-debounce-example/',
+    article15title: 'Helm Chart',
+    article15link:
+      'https://www.freecodecamp.org/news/what-is-a-helm-chart-tutorial-for-kubernetes-beginners/',
+    article16title: '80-20 Rule',
+    article16link:
+      'https://www.freecodecamp.org/news/the-80-20-rule-pareto-principle-explained-in-plain-english/',
+    article17title: 'OSI Model',
+    article17link:
+      'https://www.freecodecamp.org/news/osi-model-networking-layers-explained-in-plain-english/',
+    article18title: 'HTML Link Code',
+    article18link:
+      'https://www.freecodecamp.org/news/html-link-code-how-to-insert-a-link-to-a-website-with-href-3/',
+    article19title: 'SDLC',
+    article19link:
+      'https://www.freecodecamp.org/news/what-is-sdlc-software-development-life-cycle-phases-methodologies-and-processes-explained/',
+    article20title: 'Inductive VS Deductive',
+    article20link:
+      'https://www.freecodecamp.org/news/inductive-vs-deductive-reasoning/',
+    article21title: 'JavaScript Empty Array',
+    article21link:
+      'https://www.freecodecamp.org/news/check-if-javascript-array-is-empty-or-not-with-length/',
+    article22title: 'Best Instagram Post Time',
+    article22link:
+      'https://www.freecodecamp.org/news/the-best-time-to-post-on-instagram-the-best-days-and-times-to-reach-your-ig-followers/',
+    article23title: 'Garbage Collection in Java',
+    article23link:
+      'https://www.freecodecamp.org/news/garbage-collection-in-java-what-is-gc-and-how-it-works-in-the-jvm/',
+    article24title: 'Auto-Numbering in Excel',
+    article24link: 'https://www.freecodecamp.org/news/auto-numbering-in-excel/',
+    article25title: 'JavaScript Keycode List',
+    article25link:
+      'https://www.freecodecamp.org/news/javascript-keycode-list-keypress-event-key-codes/',
+    article26title: 'JavaScript Reverse Array',
+    article26link:
+      'https://www.freecodecamp.org/news/javascript-array-reverse-tutorial-with-example-js-code/',
+    article27title: 'How to Screenshot on Mac',
+    article27link:
+      'https://www.freecodecamp.org/news/how-to-take-a-screenshot-on-a-mac-keyboard-shortcut/',
+    article28title: 'How to Reverse Image Search',
+    article28link:
+      'https://www.freecodecamp.org/news/how-to-reverse-image-search-on-your-phone-or-desktop/',
+    article29title: 'Ternary Operator JavaScript',
+    article29link:
+      'https://www.freecodecamp.org/news/ternary-operator-javascript-if-statement-tutorial/'
+  },
+  about: 'https://www.freecodecamp.org/news/about/',
+  alumni: 'https://www.linkedin.com/school/free-code-camp/people/',
+  'open-source': 'https://github.com/freeCodeCamp/',
+  shop: 'https://www.freecodecamp.org/shop/',
+  support: 'https://www.freecodecamp.org/news/support/',
+  sponsors: 'https://www.freecodecamp.org/news/sponsors/',
+  honesty: 'https://www.freecodecamp.org/news/academic-honesty-policy/',
+  coc: 'https://www.freecodecamp.org/news/code-of-conduct/',
+  privacy: 'https://www.freecodecamp.org/news/privacy-policy/',
+  tos: 'https://www.freecodecamp.org/news/terms-of-service/',
+  copyright: 'https://www.freecodecamp.org/news/copyright-policy/'
+};

--- a/assets/config/uk/main.js
+++ b/assets/config/uk/main.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line no-unused-vars
+const ukMain = {
+  'algolia-index-name': 'news',
+  'learn-to-code-cta-url': 'https://www.freecodecamp.org/learn/',
+  'forum-url': 'https://forum.freecodecamp.org/',
+  'donate-url': 'https://www.freecodecamp.org/donate/',
+  'banner-url': 'https://www.freecodecamp.org/'
+};

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,0 +1,23 @@
+{
+  "keyword-meta": "freeCodeCamp, programming, front-end, programmer, article, regular expressions, Python, JavaScript, AWS, JSON, HTML, CSS, Bootstrap, React, Vue, Webpack",
+  "banner": "Learn to code — <span>free 3,000-hour curriculum</span>",
+  "learn-to-code-cta": "Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers.",
+  "learn-to-code-cta-btn": "Get started",
+  "footer-desc-1": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
+  "footer-desc-2": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
+  "footer-desc-3": "Donations to freeCodeCamp go toward our education initiatives and help pay for servers, services, and staff.",
+  "footer-donation": "You can <a id='footer-donation' class='inline' rel='noopener noreferrer' target='_blank'>make a tax-deductible donation here</a>.",
+  "footer-trending-guides-header": "Trending Guides",
+  "footer-our-nonprofit-header": "Our Nonprofit",
+  "footer-about": "About",
+  "footer-alumni": "Alumni Network",
+  "footer-open-source": "Open Source",
+  "footer-shop": "Shop",
+  "footer-support": "Support",
+  "footer-sponsors": "Sponsors",
+  "footer-honesty": "Academic Honesty",
+  "footer-coc": "Code of Conduct",
+  "footer-privacy": "Privacy Policy",
+  "footer-tos": "Terms of Service",
+  "footer-copyright": "Copyright Policy"
+}

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -1,0 +1,23 @@
+{
+  "keyword-meta": "freeCodeCamp, programming, front-end, programmer, article, regular expressions, Python, JavaScript, AWS, JSON, HTML, CSS, Bootstrap, React, Vue, Webpack",
+  "banner": "Learn to code — <span>free 3,000-hour curriculum</span>",
+  "learn-to-code-cta": "Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers.",
+  "learn-to-code-cta-btn": "Get started",
+  "footer-desc-1": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
+  "footer-desc-2": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
+  "footer-desc-3": "Donations to freeCodeCamp go toward our education initiatives and help pay for servers, services, and staff.",
+  "footer-donation": "You can <a id='footer-donation' class='inline' rel='noopener noreferrer' target='_blank'>make a tax-deductible donation here</a>.",
+  "footer-trending-guides-header": "Trending Guides",
+  "footer-our-nonprofit-header": "Our Nonprofit",
+  "footer-about": "About",
+  "footer-alumni": "Alumni Network",
+  "footer-open-source": "Open Source",
+  "footer-shop": "Shop",
+  "footer-support": "Support",
+  "footer-sponsors": "Sponsors",
+  "footer-honesty": "Academic Honesty",
+  "footer-coc": "Code of Conduct",
+  "footer-privacy": "Privacy Policy",
+  "footer-tos": "Terms of Service",
+  "footer-copyright": "Copyright Policy"
+}

--- a/partials/i18n.hbs
+++ b/partials/i18n.hbs
@@ -1,18 +1,84 @@
-{{!-- i18n links, trending links, and Algolia index --}}
-<script defer type="text/javascript" src="{{asset "config/en/main.js"}}"></script>
-<script defer type="text/javascript" src="{{asset "config/en/footer.js"}}"></script>
+{{! i18n links, trending links, and Algolia index }}
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/en/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/en/footer.js'}}'
+></script>
 
-<script defer type="text/javascript" src="{{asset "config/es/main.js"}}"></script>
-<script defer type="text/javascript" src="{{asset "config/es/footer.js"}}"></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/es/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/es/footer.js'}}'
+></script>
 
-<script defer type="text/javascript" src="{{asset "config/zh-cn/main.js"}}"></script>
-<script defer type="text/javascript" src="{{asset "config/zh-cn/footer.js"}}"></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/zh-cn/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/zh-cn/footer.js'}}'
+></script>
 
-<script defer type="text/javascript" src="{{asset "config/pt-br/main.js"}}"></script>
-<script defer type="text/javascript" src="{{asset "config/pt-br/footer.js"}}"></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/pt-br/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/pt-br/footer.js'}}'
+></script>
 
-<script defer type="text/javascript" src="{{asset "config/it/main.js"}}"></script>
-<script defer type="text/javascript" src="{{asset "config/it/footer.js"}}"></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/it/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/it/footer.js'}}'
+></script>
 
-{{!-- Setup global links and index objects for locale --}}
-<script defer type="text/javascript" src="{{asset "config/setup-locale.js"}}"></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/ja/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/ja/footer.js'}}'
+></script>
+
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/uk/main.js'}}'
+></script>
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/uk/footer.js'}}'
+></script>
+
+{{! Setup global links and index objects for locale }}
+<script
+  defer
+  type='text/javascript'
+  src='{{asset 'config/setup-locale.js'}}'
+></script>


### PR DESCRIPTION
Here are the changes that needs to take place for the footer to show up correctly and to  give the maintainers a translation template for the new language.

- Include language code in assets/config/ setup-local.js 
- Create an initial config folder by duplicating the assets/config/en folder and changing its name to the new language code. (en—> es for Spanish)
- Inside the new language folder, change the variable names in main.js and footer.js to the relevant language short code (enMain —> esMain for Spanish)
- Duplicate the locals/en.json and rename it to the new language code.
- In partials/i18n.hbs add scripts for config files.
- Add the related language day.js script from cdnjs to freecodecamp cdn https://cdnjs.com/libraries/dayjs/1.10.4
https://github.com/freeCodeCamp/cdn/tree/main/build/news-assets/dayjs/1.10.4/locale

Note: Everything has been setup on the instances, I just added the following change just in case.
General settings:
1. Add the following image to the twitter and 
Design-style-guides/assets/fcc_ghost_publication_cover
( I think it defaults to the publication’s banner )